### PR TITLE
Avoid resolving the promise if the callback event is canceled

### DIFF
--- a/src/bootstrap-modbox.js
+++ b/src/bootstrap-modbox.js
@@ -208,6 +208,12 @@ class modbox {
 							options.okButton.callback.call(this, ev, modal);
 						}
 
+						const defaultPrevented = ev.defaultPrevented != null ? ev.defaultPrevented : ev.returnValue === false;
+
+						if (defaultPrevented) {
+							return;
+						}
+
 						okCallback();
 					}
 				});


### PR DESCRIPTION
Now the following code will be valid:
```
let options = {
    title: null,
    body: '... custom html input ...',
    okButton: {
        label: 'Save',
        style: 'success',
        close: false,
        callback: (event, modal) => {
            if (isCustomInputValid()) {
                // hide the dialog, resolve the promise, and do something with the input
                modal.hide();
            } else {
                // keep the dialog open and don't resolve the promise
                event.preventDefault();
            }
        }
    },
    closeButton: {
        label: 'Close',
        style: 'danger'
    },
    size: 'lg',
    center: true,
    swapButtonOrder: true
};

try {
    await modbox.confirm(options);
} catch (e) {
    // Close button was clicked
    return;
}

// do something with the custom input
```